### PR TITLE
Delete 30. What is Nginx? directory

### DIFF
--- a/30. What is Nginx?/README.md
+++ b/30. What is Nginx?/README.md
@@ -1,1 +1,0 @@
-# completed


### PR DESCRIPTION
fix: remove invalid Windows filename

Extended description:
Windows does not allow `?` in file or directory names, which caused clone failures on Windows machines. The folder `30. What is Nginx?/` has been renamed to `30. What is Nginx/`, ensuring cross-platform compatibility for cloning and checking out the repository.